### PR TITLE
Template file existence check

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -163,12 +163,27 @@ class Template {
 	}
 
 	/**
+	 * Checks if template file exists
+	 *
+	 * @since  [next]
+	 * @return bool
+	 */
+	public function exists() {
+		return is_file( $this->get_path() );
+	}
+
+	/**
 	 * Renders the template
 	 *
 	 * @since  1.0.0
 	 * @return void
+	 * @throws TemplateException If teplate file does not exist.
 	 */
 	public function render() {
+
+		if ( ! $this->exists() ) {
+			throw new TemplateException( sprintf( 'Template file "%s" does not exist', $this->get_path() ) );
+		}
 
 		$get = \Closure::fromCallable( [ $this, 'get' ] );
 		$the = \Closure::fromCallable( [ $this, 'the' ] );

--- a/src/Template.php
+++ b/src/Template.php
@@ -8,6 +8,7 @@
 namespace Micropackage\Templates;
 
 use Micropackage\Templates\Exceptions\TemplateException;
+use Micropackage\Templates\Exceptions\StorageException;
 
 /**
  * Template class
@@ -39,6 +40,7 @@ class Template {
 	 * Constructor
 	 *
 	 * @throws TemplateException When variables is not an array.
+	 * @throws StorageException When storage wasn't found.
 	 * @since  1.0.0
 	 * @param  string $storage Storage name.
 	 * @param  string $name    Template name.
@@ -49,6 +51,10 @@ class Template {
 
 		$this->fs   = Storage::get( $storage );
 		$this->name = $name;
+
+		if ( empty( $this->fs ) ) {
+			throw new StorageException( sprintf( 'Storage %s wasn\'t found', $storage ) );
+		}
 
 		if ( ! is_array( $vars ) ) {
 			throw new TemplateException( sprintf( 'Template %s vars should be an array', $name ) );
@@ -169,7 +175,7 @@ class Template {
 	 * @return bool
 	 */
 	public function exists() {
-		return is_file( $this->get_path() );
+		return $this->fs->is_file( $this->get_rel_path() );
 	}
 
 	/**

--- a/tests/test-template.php
+++ b/tests/test-template.php
@@ -224,4 +224,20 @@ class TestTemplate extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @expectedException Micropackage\Templates\Exceptions\TemplateException
+	 */
+	public function test_should_throw_exception_if_template_not_found() {
+		$template = new Template( 'test', 'not-existing' );
+		$template->render();
+	}
+
+	/**
+	 * @expectedException Micropackage\Templates\Exceptions\StorageException
+	 */
+	public function test_should_throw_exception_if_storage_not_found() {
+		$template = new Template( 'no-storage', 'assets/template-no-var' );
+		$template->render();
+	}
+
 }


### PR DESCRIPTION
IMHO important function missing.
Now if template file does not exist it will produce a Warning: **"failed to open stream: No such file or directory"**. With the file existence check one could do something like this:
```php
if ( $template->exists() ) {
	$template->render();
} else {
	// render another template etc...
}
```
or
```php
try {
	$template->render();
} catch ( TemplateException $e ) {
	_e( 'Template file missing...' );
}
```

Would be useful with auto-generated template names (e.g. settings fields with template for each field type and generic template fallback for fields without dedicated template file).